### PR TITLE
Using existing document header with href attribute for link to CORS guide.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ The service will respond with a link:/understanding/JSON[JSON] representation of
 The AngularJS client will render the ID and content into the DOM.
 
 NOTE: The service at rest-service.guides.spring.io is running the code from the 
-link:/guides/gs/gs-rest-service-cors[CORS guide] with small modifications:
+{gs-rest-service-cors}[CORS guide] with small modifications:
 there is open access to the `/greeting` endpoint because the app is using 
 `@CrossOrigin` with no domain.
 


### PR DESCRIPTION
The link added in 16d269baf5a5147ccd49dd15f8c2c4832fd15b8b incorrectly resolves to http://spring.io/guides/gs/gs-rest-service-cors/

The correct link is http://spring.io/guides/gs/rest-service-cors/

The document already had a working link to the CORS guide, so I leveraged that instead.